### PR TITLE
Harden Sonar workflows against fork-PR injection and fix SonarCloud org key

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -34,19 +34,28 @@ jobs:
       - name: Run tests
         run: go test -race -vet=off -coverprofile=coverage.out ./...
 
-      # Package up PR context for downstream workflow_run
+      # Package up PR context for downstream workflow_run.
+      # User-controlled values (branch/repo names) are passed via env vars and
+      # serialized with `jq --arg` so they are treated as data, never injected
+      # into the shell or the generated JSON.
       - name: Prepare PR context artifact
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          cat > pr-context.json <<'JSON'
-          {
-            "pr_number": "${{ github.event.pull_request.number }}",
-            "head_sha":  "${{ github.event.pull_request.head.sha }}",
-            "head_repo": "${{ github.event.pull_request.head.repo.full_name }}",
-            "head_branch": "${{ github.event.pull_request.head.ref }}",
-            "base_ref": "${{ github.event.pull_request.base.ref }}",
-            "run_id": "${{ github.run_id }}"
-          }
-          JSON
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg head_repo "$HEAD_REPO" \
+            --arg head_branch "$HEAD_BRANCH" \
+            --arg base_ref "$BASE_REF" \
+            --arg run_id "$RUN_ID" \
+            '{pr_number: $pr_number, head_sha: $head_sha, head_repo: $head_repo, head_branch: $head_branch, base_ref: $base_ref, run_id: $run_id}' \
+            > pr-context.json
           cat pr-context.json
 
       - name: Upload PR context

--- a/.github/workflows/dispatch-sonar.yml
+++ b/.github/workflows/dispatch-sonar.yml
@@ -33,21 +33,31 @@ jobs:
           echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
           echo "run_id=$(jq -r '.run_id' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
 
+      # Step outputs derive from the fork PR and are user-controlled. Pass them
+      # through env vars and read via process.env so they are never interpolated
+      # into the script source (a value containing a quote could inject code).
       - name: Dispatch Sonar workflow with inputs
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.ctx.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.ctx.outputs.head_branch }}
+          BASE_REF: ${{ steps.ctx.outputs.base_ref }}
+          RUN_ID: ${{ steps.ctx.outputs.run_id }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'sonar.yml',
-              ref: '${{ steps.ctx.outputs.base_ref }}',
+              ref: process.env.BASE_REF,
               inputs: {
-                pr_number:  '${{ steps.ctx.outputs.pr_number }}',
-                head_sha:   '${{ steps.ctx.outputs.head_sha }}',
-                head_repo:  '${{ steps.ctx.outputs.head_repo }}',
-                head_branch:'${{ steps.ctx.outputs.head_branch }}',
-                base_ref:   '${{ steps.ctx.outputs.base_ref }}',
-                run_id:     '${{ steps.ctx.outputs.run_id }}'
+                pr_number:   process.env.PR_NUMBER,
+                head_sha:    process.env.HEAD_SHA,
+                head_repo:   process.env.HEAD_REPO,
+                head_branch: process.env.HEAD_BRANCH,
+                base_ref:    process.env.BASE_REF,
+                run_id:      process.env.RUN_ID
               }
             });

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,14 +26,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Workflow inputs originate from a fork PR and are user-controlled.
+      # Pass them via env vars so the shell treats them as data, never as
+      # interpolated code, when writing to $GITHUB_ENV.
       - name: Export context
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPO: ${{ inputs.head_repo }}
+          PR_BRANCH: ${{ inputs.head_branch }}
+          BASE_BRANCH: ${{ inputs.base_ref }}
+          UPSTREAM_RUN_ID: ${{ inputs.run_id }}
         run: |
-          echo "PR_NUMBER=${{ inputs.pr_number }}"    >> $GITHUB_ENV
-          echo "HEAD_SHA=${{ inputs.head_sha }}"      >> $GITHUB_ENV
-          echo "HEAD_REPO=${{ inputs.head_repo }}"    >> $GITHUB_ENV
-          echo "PR_BRANCH=${{ inputs.head_branch }}"  >> $GITHUB_ENV
-          echo "BASE_BRANCH=${{ inputs.base_ref }}"   >> $GITHUB_ENV
-          echo "UPSTREAM_RUN_ID=${{ inputs.run_id }}" >> $GITHUB_ENV
+          {
+            echo "PR_NUMBER=$PR_NUMBER"
+            echo "HEAD_SHA=$HEAD_SHA"
+            echo "HEAD_REPO=$HEAD_REPO"
+            echo "PR_BRANCH=$PR_BRANCH"
+            echo "BASE_BRANCH=$BASE_BRANCH"
+            echo "UPSTREAM_RUN_ID=$UPSTREAM_RUN_ID"
+          } >> "$GITHUB_ENV"
 
       - name: Generate token
         id: app_token

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=CZERTAINLY_CBOM-Repository
-sonar.organization=czertainly
+sonar.projectKey=ilm_cbom-repository
+sonar.organization=ilm
 
 sonar.go.coverage.reportPaths=coverage.out
 sonar.go.golangci-lint.reportPaths=golangci-lint-report.xml


### PR DESCRIPTION
## Summary

CodeQL/SonarCloud flagged the Sonar-related workflows for using **user-controlled data** (fork branch/repo names from `github.event.pull_request.*` and the downstream inputs derived from them) directly in `run:`/`github-script` blocks. GitHub Actions `${{ }}` expressions are substituted *before* the shell or github-script runs, so a crafted branch or repo name could inject shell commands, JS code, or break the generated JSON.

## Changes

- **`check_pr.yml`** — build `pr-context.json` via `env:` vars + `jq --arg` (safe escaping, valid JSON) instead of interpolating `${{ }}` into a heredoc.
- **`sonar.yml`** — pass the fork-controlled `workflow_dispatch` inputs through `env:` vars before writing to `$GITHUB_ENV`.
- **`dispatch-sonar.yml`** — pass step outputs through `env:` vars and read them via `process.env` in the github-script dispatch step.

Output shapes (JSON keys, `$GITHUB_ENV` vars, dispatch inputs) and behavior are unchanged.

## Notes

This clears the SonarCloud "user-controlled data in a run block" finding that is currently blocking the other open PRs. Once merged to `main`, the remaining PRs pass Sonar on their next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)