### PR TITLE
Rebrand czertainly to ILM in the Helm chart

### DIFF
--- a/deploy/charts/cbom-repository/Chart.lock
+++ b/deploy/charts/cbom-repository/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: czertainly-lib
-  repository: oci://harbor.3key.company/czertainly-helm
-  version: 1.4.2
-digest: sha256:25333e03c2313df6d0e23354b76f2d96a92295da480353fd6b6f107e070d887e
-generated: "2025-11-06T18:37:01.417586+01:00"
+- name: ilm-lib
+  repository: oci://hub.omnitrustregistry.com/ilm-helm
+  version: 1.4.2-1
+digest: sha256:c5ea4977a5c185a89ae797ecb61aa430ebea416eafb0e820d3841970f9844bf6
+generated: "2026-08-01T12:07:24.8485218+02:00"

--- a/deploy/charts/cbom-repository/Chart.yaml
+++ b/deploy/charts/cbom-repository/Chart.yaml
@@ -7,10 +7,10 @@ description: A Helm chart for CBOM Repository.
 home: https://github.com/OmniTrustILM/cbom-repository
 icon: https://github.com/OmniTrustILM.png
 dependencies:
-  - name: czertainly-lib
-    repository: oci://harbor.3key.company/czertainly-helm
-    # repository: file://../czertainly-lib
-    version: 1.4.2
+  - name: ilm-lib
+    repository: oci://hub.omnitrustregistry.com/ilm-helm
+    # repository: file://../ilm-lib
+    version: 1.4.2-1
 keywords:
   - ilm
   - trust

--- a/deploy/charts/cbom-repository/README.md
+++ b/deploy/charts/cbom-repository/README.md
@@ -28,7 +28,7 @@ kubectl create namespace ilm
 
 Copy the default `values.yaml` from the Helm chart and modify the values accordingly:
 ```bash
-helm show values oci://harbor.3key.company/czertainly-helm/cbom-repository > values.yaml
+helm show values oci://hub.omnitrustregistry.com/ilm-helm/cbom-repository > values.yaml
 ```
 Now edit the `values.yaml` according to your desired state, see [Configurable parameters](#configurable-parameters) for more information.
 
@@ -36,7 +36,7 @@ Now edit the `values.yaml` according to your desired state, see [Configurable pa
 
 For the basic installation, run:
 ```bash
-helm install --namespace ilm -f values.yaml ilm-cbom-repository oci://harbor.3key.company/czertainly-helm/cbom-repository
+helm install --namespace ilm -f values.yaml ilm-cbom-repository oci://hub.omnitrustregistry.com/ilm-helm/cbom-repository
 ```
 
 **Save your configuration**
@@ -50,7 +50,7 @@ Always make sure you save the `values.yaml` and all `--set` and `--set-file` opt
 
 For upgrading the installation, update your configuration and run:
 ```bash
-helm upgrade --namespace ilm -f values.yaml ilm-cbom-repository oci://harbor.3key.company/czertainly-helm/cbom-repository
+helm upgrade --namespace ilm -f values.yaml ilm-cbom-repository oci://hub.omnitrustregistry.com/ilm-helm/cbom-repository
 ```
 
 ### Uninstall
@@ -98,8 +98,8 @@ The following values may be configured:
 | httpProxy                                    | `""`                        | Proxy to be used to access external resources through http            |
 | httpsProxy                                   | `""`                        | Proxy to be used to access external resources through https           |
 | noProxy                                      | `""`                        | Defines list of external resources that should not use proxy settings |
-| image.registry                               | `docker.io`                 | Docker registry name for the image                                    |
-| image.repository                             | `czertainly`                | Docker image repository name                                          |
+| image.registry                               | `hub.omnitrustregistry.com` | Docker registry name for the image                                    |
+| image.repository                             | `ilm`                       | Docker image repository name                                          |
 | image.name                                   | `cbom-repository`           | Docker image name                                                     |
 | image.tag                                    | `1.0.0`                     | Docker image tag                                                      |
 | image.digest                                 | `""`                        | Docker image digest, will override tag if specified                   |

--- a/deploy/charts/cbom-repository/templates/_helpers.tpl
+++ b/deploy/charts/cbom-repository/templates/_helpers.tpl
@@ -65,110 +65,110 @@ Create the name of the service account to use
 Return the image name
 */}}
 {{- define "cbom-repository.image" -}}
-{{ include "czertainly-lib.images.image" (dict "image" .Values.image "global" .Values.global) }}
+{{ include "ilm-lib.images.image" (dict "image" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the image name of the curl
 */}}
 {{- define "cbom-repository.curl.image" -}}
-{{ include "czertainly-lib.images.image" (dict "image" .Values.curl.image "global" .Values.global) }}
+{{ include "ilm-lib.images.image" (dict "image" .Values.curl.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the image name of the minio
 */}}
 {{- define "cbom-repository.minio.image" -}}
-{{ include "czertainly-lib.images.image" (dict "image" .Values.minio.image "global" .Values.global) }}
+{{ include "ilm-lib.images.image" (dict "image" .Values.minio.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the image pull secret names
 */}}
 {{- define "cbom-repository.imagePullSecrets" -}}
-{{ include "czertainly-lib.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{ include "ilm-lib.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Render init containers, if any
 */}}
 {{- define "cbom-repository.customization.initContainers" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.initContainers .Values.initContainers) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.initContainers .Values.initContainers) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render sidecar containers, if any
 */}}
 {{- define "cbom-repository.customization.sidecarContainers" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.sidecarContainers .Values.sidecarContainers) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.sidecarContainers .Values.sidecarContainers) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render additional volumes, if any
 */}}
 {{- define "cbom-repository.customization.volumes" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumes .Values.additionalVolumes) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumes .Values.additionalVolumes) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render additional volume mounts, if any
 */}}
 {{- define "cbom-repository.customization.volumeMounts" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumeMounts .Values.additionalVolumeMounts) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumeMounts .Values.additionalVolumeMounts) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized ports, if any
 */}}
 {{- define "cbom-repository.customization.ports" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalPorts .Values.additionalPorts) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalPorts .Values.additionalPorts) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized environment variables, if any
 */}}
 {{- define "cbom-repository.customization.env" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.additionalEnv.variables) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.additionalEnv.variables) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized environment variables from configmaps and secrets, if any
 */}}
 {{- define "cbom-repository.customization.envFrom" -}}
-{{- include "czertainly-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.additionalEnv.configMaps) "context" $ ) }}
-{{- include "czertainly-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.additionalEnv.secrets) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.additionalEnv.configMaps) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.additionalEnv.secrets) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized environment variables, if any
 */}}
 {{- define "cbom-repository.minio.customization.env" -}}
-{{- include "czertainly-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.minio.additionalEnv.variables) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.minio.additionalEnv.variables) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized environment variables from configmaps and secrets, if any
 */}}
 {{- define "cbom-repository.minio.customization.envFrom" -}}
-{{- include "czertainly-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.minio.additionalEnv.configMaps) "context" $ ) }}
-{{- include "czertainly-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.minio.additionalEnv.secrets) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.minio.additionalEnv.configMaps) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.minio.additionalEnv.secrets) "context" $ ) }}
 {{- end -}}
 
 {{/*
 Render customized command and arguments, if any
 */}}
 {{- define "cbom-repository.image.command" -}}
-{{- include "czertainly-lib.tplvalues.render" (dict "value" .Values.image.command "context" $) }}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.command "context" $) }}
 {{- end -}}
 
 {{- define "cbom-repository.image.args" -}}
-{{- include "czertainly-lib.tplvalues.render" (dict "value" .Values.image.args "context" $) }}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.args "context" $) }}
 {{- end -}}
 
 {{- define "cbom-repository.minio.image.command" -}}
-{{- include "czertainly-lib.tplvalues.render" (dict "value" .Values.minio.image.command "context" $) }}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.minio.image.command "context" $) }}
 {{- end -}}
 
 {{- define "cbom-repository.minio.image.args" -}}
-{{- include "czertainly-lib.tplvalues.render" (dict "value" .Values.minio.image.args "context" $) }}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.minio.image.args "context" $) }}
 {{- end -}}

--- a/deploy/charts/cbom-repository/templates/trusted-certificates-secret.yaml
+++ b/deploy/charts/cbom-repository/templates/trusted-certificates-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.trusted.certificates }}
-{{- include "czertainly-lib.trusted.certificates.secret.local" (list . "cbom-repository.trusted.certificates.secret") -}}
+{{- include "ilm-lib.trusted.certificates.secret.local" (list . "cbom-repository.trusted.certificates.secret") -}}
 {{- end }}
 
 {{- define "cbom-repository.trusted.certificates.secret" -}}

--- a/deploy/charts/cbom-repository/values.yaml
+++ b/deploy/charts/cbom-repository/values.yaml
@@ -62,10 +62,8 @@ noProxy: ""
 replicaCount: 1
 
 image:
-  # default registry name
-  registry: docker.io
-  # kept on czertainly until the image is published under omnitrustilm (see #122)
-  repository: czertainly
+  registry: hub.omnitrustregistry.com
+  repository: ilm
   name: cbom-repository
   tag: 1.0.0
   # the digest to be used instead of the tag
@@ -123,11 +121,9 @@ image:
 
 curl:
   image:
-    # default registry name
-    registry: docker.io
-    # kept on czertainly until the image is published under omnitrustilm (see #122)
-    repository: czertainly
-    name: czertainly-curl
+    registry: hub.omnitrustregistry.com
+    repository: ilm
+    name: curl
     tag: 8.16.0
     # the digest to be used instead of the tag
     digest: ""
@@ -236,11 +232,10 @@ minio:
   enabled: false
 
   image:
-    # default registry name
-    registry: docker.io
-    # minio is discontinued; kept on czertainly pending an S3-compatible alternative (see #121)
-    repository: czertainly
-    name: czertainly-minio
+    # minio is discontinued, pending an S3-compatible alternative (see #121)
+    registry: hub.omnitrustregistry.com
+    repository: ilm
+    name: minio
     tag: RELEASE.2025-09-07T16-13-09Z
     # the digest to be used instead of the tag
     digest: ""


### PR DESCRIPTION
## What

Full czertainly → ILM rebrand of the cbom-repository Helm chart.

**Docker images** → `hub.omnitrustregistry.com/ilm/…`
- main: `docker.io/czertainly/cbom-repository` → `hub.omnitrustregistry.com/ilm/cbom-repository`
- curl: `czertainly/czertainly-curl` → `hub.omnitrustregistry.com/ilm/curl`
- minio: `czertainly/czertainly-minio` → `hub.omnitrustregistry.com/ilm/minio`

**Helm library dependency**
- `czertainly-lib` → `ilm-lib`, repository `oci://harbor.3key.company/czertainly-helm` → `oci://hub.omnitrustregistry.com/ilm-helm`, version `1.4.2` → `1.4.2-1` (the republished, rebranded library chart).
- All `czertainly-lib.*` template include prefixes and the trusted-certificates helper renamed to `ilm-lib.*`.
- `Chart.lock` regenerated against the new dependency.

**Docs**
- Chart README install/upgrade commands repointed to the new oci path; `image.registry`/`image.repository` parameter defaults updated.

## Validation

- `helm dependency update` pulls `ilm-lib:1.4.2-1` successfully.
- `helm lint` — clean.
- `helm template` — renders with no errors, no remaining czertainly; images resolve to `hub.omnitrustregistry.com/ilm/…`.

## Notes

- `publish_chart.yaml` needs no change — its target registry/repository come from `HELM_OCI_REGISTRY` / `HELM_OCI_REPOSITORY` secrets, not hardcoded.